### PR TITLE
ci: add semantic release configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
                 args: --release
 
           - name: Disable "include adminstrator" Branch Protection
-            uses: @benjefferies/branch-protection-bot@1
+            uses: benjefferies/branch-protection-bot@1
             if: always()
             with:
                 access-token: ${{ secrets.SEMRELGH }}
@@ -97,7 +97,7 @@ jobs:
                 CARGO_REGISTRY_TOKEN: ${{ secrets.SEMREL_CRATES_IO }}
 
           - name: Enable "include adminstrator" Branch Protection
-            uses: @benjefferies/branch-protection-bot@1
+            uses: benjefferies/branch-protection-bot@1
             if: always()
             with:
                 access-token: ${{ secrets.SEMRELGH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
+      - alpha
 
 env:
   RUST_BACKTRACE: 1
@@ -12,6 +13,7 @@ jobs:
 
   test:
     name: Test ${{ matrix.rust }}
+    if: "!contains(github.event.commits[0].message, '[skip ci]')"
     strategy:
       matrix:
         rust:
@@ -51,3 +53,51 @@ jobs:
         with:
           command: test
 
+  release:
+      name: Semantic Release
+      if: github.event_name == 'push'
+      runs-on: ubuntu-latest
+      needs: ['test']
+
+      steps:
+          - name: Checkout
+            uses: actions/checkout@v2
+            with:
+                fetch-depth: 0
+
+          - name: Install Rust Stable
+            uses: actions-rs/toolchain@v1
+            with:
+                profile: minimal
+                toolchain: stable
+                override: true
+
+          - name: Build
+            uses: actions-rs/cargo@v1
+            with:
+                command: build
+                args: --release
+
+          - name: Disable "include adminstrator" Branch Protection
+            uses: @benjefferies/branch-protection-bot@1
+            if: always()
+            with:
+                access-token: ${{ secrets.SEMRELGH }}
+
+          - name: Semantic Release
+            uses: cycjimmy/semantic-release-action@v2
+            with:
+                semantic_version: 17.1.1
+                dry_run: true
+                extra_plugins: |
+                    @semantic-release/git@9.0
+                    @semantic-release/exec@5.0
+            env:
+                GITHUB_TOKEN: ${{ secrets.SEMRELGH }}
+                CARGO_REGISTRY_TOKEN: ${{ secrets.SEMREL_CRATES_IO }}
+
+          - name: Enable "include adminstrator" Branch Protection
+            uses: @benjefferies/branch-protection-bot@1
+            if: always()
+            with:
+                access-token: ${{ secrets.SEMRELGH }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,22 @@
+branches:
+  - +([0-9])?(.{+([0-9]),x}).x
+  - main
+  - next
+  - next-major
+  - name: beta
+    prerelease: true
+  - name: alpha
+    prerelease: true
+
+plugins:
+    - '@semantic-release/commit-analyzer'
+    - '@semantic-release/release-notes-generator'
+    - '@semantic-release/github'
+    - - '@semantic-release/exec'
+      - verifyConditionsCmd: "./target/release/semantic-release-rust verify-conditions"
+        prepareCmd: "./target/release/semantic-release-rust prepare"
+        publishCmd: "./target/release/semantic-release-rust publish"
+    - - '@semantic-release/git'
+      - assets:
+        - Cargo.toml
+        - Cargo.lock


### PR DESCRIPTION
Set to do a dry run that: releases to github, publishes to crates.io
and committes the updated Cargo.toml and Cargo.lock files.