### PR TITLE
ci(release): change git commit strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
             uses: peter-evans/create-pull-request@v3.1.0
             if: steps.semantic.outputs.new_release_published == 'true'
             with:
-                token: ${{ secretes.SEMRELGH }}
+                token: ${{ secrets.SEMRELGH }}
                 commit-message: 'chore(release): version ${{ steps.semantic.ouputs.new_release_version }}'
                 committer: sbosnick-bot <sbosnick@gmail.com>
                 author: sbosnick-bot <sbosnick@gmail.com>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,23 +79,9 @@ jobs:
                 command: build
                 args: --release
 
-          - name: Get Current Branch
-            # set the output "branch" to everything after the last "/"
-            # in GITHUB_REF. This will not work properly on pull requests
-            # but this job is restricted to push's.
-            run: echo "::set-output name=branch::${GITHUB_REF##*/}"
-            shell: bash
-            id: get-branch
-
-          - name: Disable "include adminstrator" Branch Protection
-            uses: benjefferies/branch-protection-bot@1.0.4
-            if: always()
-            with:
-                access-token: ${{ secrets.SEMRELGH }}
-                branch: ${{ steps.get-branch.outputs.branch }}
-
           - name: Semantic Release
             uses: cycjimmy/semantic-release-action@v2
+            id: semantic
             with:
                 semantic_version: 17.1.1
                 extra_plugins: |
@@ -105,9 +91,14 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.SEMRELGH }}
                 CARGO_REGISTRY_TOKEN: ${{ secrets.SEMREL_CRATES_IO }}
 
-          - name: Enable "include adminstrator" Branch Protection
-            uses: benjefferies/branch-protection-bot@1.0.4
-            if: always()
+          - name: Create Pull Request
+            uses: peter-evans/create-pull-request@v3.1.0
+            if: steps.semantic.outputs.new_release_published == 'true'
             with:
-                access-token: ${{ secrets.SEMRELGH }}
-                branch: ${{ steps.get-branch.outputs.branch }}
+                token: ${{ secretes.SEMRELGH }}
+                commit-message: 'chore(release): version ${{ steps.semantic.ouputs.new_release_version }}'
+                committer: sbosnick-bot <sbosnick@gmail.com>
+                author: sbosnick-bot <sbosnick@gmail.com>
+                branch: release-bot/${{ steps.semantic.ouputs.new_release_version }}
+                title: 'chore(release): version ${{ steps.semantic.ouputs.new_release_version }}'
+                body: 'Version bump in Crates.io files for release[${{ steps.semantic.ouputs.new_release_version }}](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semantic.ouputs.new_release_version }})\n\n[skip ci]'

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -16,7 +16,3 @@ plugins:
       - verifyConditionsCmd: "./target/release/semantic-release-rust verify-conditions"
         prepareCmd: "./target/release/semantic-release-rust prepare ${nextRelease.version}"
         publishCmd: "./target/release/semantic-release-rust publish"
-    - - '@semantic-release/git'
-      - assets:
-        - Cargo.toml
-        - Cargo.lock


### PR DESCRIPTION
The old strategy for committing version number bumps was to try to push the changed Cargo.toml (and related) files
directly to the branch being released. The semantic-release part of the CI workflow attempted to turn off branch protection
around running semantic-release to allow this to work with branch protection. It didn't work.

The new workflow instead creates a pull request on a new branch to add the changed Cargo.toml (and related) files back
to the branch being release. This will (eventually) be supplemented with a different workflow to automatically approve and
merge this pull request.