### PR TITLE
feat(cli): add default allow dirty to publish

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,11 +77,13 @@ enum Subcommand {
     ///
     /// Publishing the workspace publishes each crate in the workspace to
     /// crates.io except crates with the `package.publish` field set to `false` or
-    /// set to any registries other than just crates.io.
+    /// set to any registries other than just crates.io. By default this will publish
+    /// with the `allow-dirty` flag but this can be excluded with the `no-dirty`
+    /// flag to this subcommand.
     ///
     /// This implments the `publish` step for `semantic-release` for a Cargo-based
     /// Rust workspace.
-    Publish(CommonOpt),
+    Publish(PublishOpt),
 }
 
 #[derive(StructOpt)]
@@ -100,6 +102,16 @@ struct PrepareOpt {
     next_version: String,
 }
 
+#[derive(StructOpt)]
+struct PublishOpt {
+    #[structopt(flatten)]
+    common: CommonOpt,
+
+    /// Disallow publishing with uncommited files in the workspace.
+    #[structopt(long)]
+    no_dirty: bool,
+}
+
 impl Subcommand {
     fn run(&self, w: impl Write) -> Result<(), Error> {
         use Subcommand::*;
@@ -108,7 +120,7 @@ impl Subcommand {
             ListPackages(opt) => Ok(list_packages(w, opt.manifest_path())?),
             VerifyConditions(opt) => Ok(verify_conditions(w, opt.manifest_path())?),
             Prepare(opt) => Ok(prepare(w, opt.common.manifest_path(), &opt.next_version)?),
-            Publish(opt) => Ok(publish(w, opt.manifest_path())?),
+            Publish(opt) => Ok(publish(w, opt.common.manifest_path(), opt.no_dirty)?),
         }
     }
 }


### PR DESCRIPTION
The publish subcommmand previously did not allow publication if
there were any uncommitted files in the working directory (the
default behaviour of "cargo publish"). Change the default behaviour
to use the "--allow-dirty" flag to "cargo publish" and provide a
"--no-dirty" flag to the publish subcommmand to go back to the
original behaviour.

The default use of "--allow-dirty" is reasonable because the prepare
subcommmand will make changes to the files in the workspace (specifically
the Cargo.toml files). These changes may or may not be committed to the
git repository by the time the publish subcommmand is run.