### PR TITLE
chore(release): version 1.0.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "semantic-release-rust"
-version = "0.1.0"
+version = "1.0.0-alpha.4"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-release-rust"
-version = "0.1.0"
+version ="1.0.0-alpha.4"
 authors = ["Steven Bosnick <sbosnick@sympatico.ca>"]
 edition = "2018"
 description = "A CLI to integrate Rust into a semantic-release workflow."


### PR DESCRIPTION
Version bump in Crates.io files for release [1.0.0-alpha.4](https://github.com/sbosnick/semantic-release-rust/releases/tag/v1.0.0-alpha.4)

[skip ci]