### PR TITLE
ci(release): remove verbose flags on rust publish

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -15,4 +15,4 @@ plugins:
     - - '@semantic-release/exec'
       - verifyConditionsCmd: "./target/release/semantic-release-rust verify-conditions"
         prepareCmd: "./target/release/semantic-release-rust prepare ${nextRelease.version}"
-        publishCmd: "./target/release/semantic-release-rust -vv publish"
+        publishCmd: "./target/release/semantic-release-rust publish"


### PR DESCRIPTION
The publish command for semantic-release-rust had used the "-vv"
flag for debugging. This removes that flag.