### PR TITLE
fix: add auto merge workflow for bot PR's

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,36 @@
+name: Automerge
+
+on:
+    pull_request:
+        types:
+            - labeled
+            - unlabeled
+            - synchronize
+            - opened
+            - edited
+            - ready_for_review
+            - reopended
+            - unlocked
+    pull_request_review:
+        types:
+            - submitted
+    check_suite:
+        types:
+            - completed
+    status: {}
+
+jobs:
+    auto_merge:
+        name: Auto Approve PR
+        runs-on: ubuntu-latest
+        if: github.actor == 'sbosnick-bot'
+        steps:
+           - name: Auto Merge
+             uses: pascalgn/automerge-action@v0.9.0
+             env:
+                 GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+                 MERGE_METHOD: "squash"
+                 MERGE_COMMIT_MESSAGE: "pull-request-title-and-description"
+                 MERGE_FORKS: "false"
+                 MERGE_RETRIES: "10"
+                 MERGE_RETRY_SLEEP: "10000"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
                 committer: sbosnick-bot <sbosnick@gmail.com>
                 author: sbosnick-bot <sbosnick@gmail.com>
                 branch: release-bot/${{ steps.semantic.outputs.new_release_version }}
+                labels: "automerge"
                 title: 'chore(release): version ${{ steps.semantic.outputs.new_release_version }}'
                 body: >
                     Version bump in Crates.io files for release


### PR DESCRIPTION
The auto merge job will run for various events associated with a PR but
restricted to PR's submitted by "sbosnick-bot". The PR generated at the
end of the release job in the CI workflow will be such a PR.

Note that the secret containing personal access token used by the PR
step in the release job was updated (outside of this commit) as a token
for the sbosnick-bot user.