### PR TITLE
ci: add test to gate ci workflow against bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
 
   test:
     name: Test ${{ matrix.rust }}
-    if: "!contains(github.event.commits[0].message, '[skip ci]')"
+    if: >-
+        !contains(github.event.commits[0].message, '[skip ci]')
+        && github.actor != 'sbosnick-bot'
     strategy:
       matrix:
         rust:


### PR DESCRIPTION
Add an if condition to the test job in the ci workflow to check if the author
of the pull request or the push was the bot "sbosnick-bot". Currently this is
designed to exclude the ci workflow for the pull request generated as the last
step of the release job (which is generated using a token for the "sbosnick-bot"
user). The assumption is that the bot will run any needed tests on its own before
creating the PR.

[skip ci]