### PR TITLE
fix(doc): correct install documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and `publish` step of [semantic-release].
 Install `semantic-release-rust` with
 
 ```bash
-$ cargo install semantic-release-rust
+$ cargo install semantic-release-rust --version 1.0.0-alpha.6
 ```
 
 then add it to your `semantic-release` configuration using the [`semantic-release/exec`][exec]


### PR DESCRIPTION
The cargo install command given in the README.md file would report
an error because crates.io currenly only has prerelease versions on
it. The new cargo install command given in README.md specifically lists
a particular alpha version to install. This will no longer be necessary
once a 1.0.0 version has been released.

This is a bug fix because README.md is the landing page for the crate
on crates.io and so the installation instructions are effectivily a part
of the published "api".

fixes: #20