### PR TITLE
fix(build): update guppy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ loggerv = "0.7.2"
 structopt = "0.3.15"
 anyhow = "1.0.31"
 thiserror = "1.0.20"
-guppy = "0.5.0"
+guppy = "0.6.3"
 itertools = "0.9.0"
 toml_edit = "0.2.0"
 serde = {version = "1.0.114", features = ["derive"]}


### PR DESCRIPTION
When I updated to `nightly 1.51.0` I started receiving errors that `guppy` could not compile. I tried updating the version from `0.5.0` to the latest `0.6.3` and everything seems to compile nicely with the newer version.

```
error[E0284]: type annotations needed: cannot satisfy `<_ as GraphSpec>::Ix == FeatureIx`
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/guppy-0.5.0/src/graph/feature/resolve.rs:238:14
    |
238 |             .topo(graph.sccs(), direction)
    |              ^^^^ cannot satisfy `<_ as GraphSpec>::Ix == FeatureIx`

error[E0284]: type annotations needed: cannot satisfy `<_ as GraphSpec>::Ix == FeatureIx`
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/guppy-0.5.0/src/graph/feature/resolve.rs:256:14
    |
256 |             .topo(graph.sccs(), direction)
    |              ^^^^ cannot satisfy `<_ as GraphSpec>::Ix == FeatureIx`

error[E0284]: type annotations needed: cannot satisfy `<_ as GraphSpec>::Node == feature::graph_impl::FeatureNode`
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/guppy-0.5.0/src/graph/feature/resolve.rs:308:14
    |
308 |             .roots(dep_graph, self.graph.sccs(), direction)
    |              ^^^^^ cannot satisfy `<_ as GraphSpec>::Node == feature::graph_impl::FeatureNode`
```