### PR TITLE
ci: remove conventional commit check from mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,21 +7,6 @@ queue_rules:
       - check-success=Test 1.45.0
 
 pull_request_rules:
-  - name: Conventional Commit
-    conditions:
-      - "title~=^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"
-    actions:
-      post_check:
-        title: |
-          {% if check_succeed %}
-          Title follows Conventional Commit
-          {% else %}
-          Title does not follow Conventional Commit
-          {% endif %}
-        summary: |
-          {% if not check_succeed %}
-          Your pull request title must follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/).
-          {% endif %}
   - name: Queue on approval with success checks
     conditions:
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
The "post_check" action on which it depends is a premium plan feature
and we are not subscribed to that plan.