### PR TITLE
ci: add mergify rule for own pull requests

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,3 +17,14 @@ pull_request_rules:
     actions:
       queue:
         name: default
+
+  - name: Queue on success checks for sbosnick
+    conditions:
+      - author=sbosnick
+      - check-success=Test stable
+      - check-success=Test beta
+      - check-success=Test nightly
+      - check-success=Test 1.45.0
+    actions:
+      queue:
+        name: default


### PR DESCRIPTION
Github does not allow someone to approve their own pull request which
has the effect (on this single contributor project) of making the
"approval with success checks" rule imposible to satisfy. The new
"author=sbosnick" rule will allow me to submit pull requests that
mergify handles.

The implication of this, though, is that me submitting a sucessful pull
request to a branch on which semantic release is active will result in a
release of the project (for the types of commit messages that trigger
such releases).